### PR TITLE
Closes #19 update for admiral 1.0

### DIFF
--- a/adam/adpc.qmd
+++ b/adam/adpc.qmd
@@ -223,6 +223,7 @@ adpc_prev <- adpc_first_dose %>%
       AENDTM_prev = AENDTM
     ),
     join_vars = exprs(ADTM),
+    join_type = "all",
     filter_add = NULL,
     filter_join = ADTM > ADTM.join,
     mode = "last",
@@ -239,6 +240,7 @@ adpc_next <- adpc_prev %>%
       AENDTM_next = AENDTM
     ),
     join_vars = exprs(ADTM),
+    join_type = "all",
     filter_add = NULL,
     filter_join = ADTM <= ADTM.join,
     mode = "first",
@@ -260,6 +262,7 @@ adpc_nom_prev <- adpc_next %>%
     order = exprs(NFRLT),
     new_vars = exprs(NFRLT_prev = NFRLT),
     join_vars = exprs(NFRLT),
+    join_type = "all",
     filter_add = NULL,
     filter_join = NFRLT > NFRLT.join,
     mode = "last",
@@ -273,6 +276,7 @@ adpc_nom_next <- adpc_nom_prev %>%
     order = exprs(NFRLT),
     new_vars = exprs(NFRLT_next = NFRLT),
     join_vars = exprs(NFRLT),
+    join_type = "all",
     filter_add = NULL,
     filter_join = NFRLT <= NFRLT.join,
     mode = "first",

--- a/adam/adppk.qmd
+++ b/adam/adppk.qmd
@@ -228,6 +228,7 @@ adppk_prev <- adppk_first_dose %>%
       AENDTM_prev = AENDTM
     ),
     join_vars = exprs(ADTM),
+    join_type = "all",
     filter_add = NULL,
     filter_join = ADTM > ADTM.join,
     mode = "last",
@@ -247,6 +248,7 @@ adppk_nom_prev <- adppk_prev %>%
     order = exprs(NFRLT),
     new_vars = exprs(NFRLT_prev = NFRLT),
     join_vars = exprs(NFRLT),
+    join_type = "all",
     filter_add = NULL,
     filter_join = NFRLT > NFRLT.join,
     mode = "last",


### PR DESCRIPTION
Added `join_type` for adpc.qmd and adppk.qmd.  Did not see any required udpates for adsl.qmd.