### PR TITLE
Add installation guide for running the examples locally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,8 +21,7 @@ Imports:
     stringr,
     tern,
     tidyr,
-    xportr,
-    desc
+    xportr
 Suggests:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Imports:
     stringr,
     tern,
     tidyr,
-    xportr
+    xportr,
+    desc
 Suggests:
     knitr,
     rmarkdown

--- a/index.qmd
+++ b/index.qmd
@@ -52,20 +52,8 @@ or,
 
 * Use the code provided below to install the necessary packages, then copy and paste the example code directly into your R console.
 
-```{r results = "asis", echo = FALSE}
-deps <- desc::desc(file = "DESCRIPTION")$get_deps()
-imported_deps <- deps[deps$type == "Imports" & deps$package != "desc", "package"]
-
-cat(
-  paste0(
-    "```r\n",
-    "install.packages(c(",
-    paste0("'", imported_deps, "'", collapse = ", "),
-    "))\n",
-    "```"
-  )
-)
-
+```r
+install.packages(c("admiral", "dplyr", "lubridate", "metacore", "metatools", "pharmaversesdtm", "pharmaverseadam", "stringr", "tern", "tidyr", "xportr"))
 ```
 
 ## Contributing

--- a/index.qmd
+++ b/index.qmd
@@ -52,8 +52,20 @@ or,
 
 * Use the code provided below to install the necessary packages, then copy and paste the example code directly into your R console.
 
-```r
-install.packages(c("admiral", "dplyr", "lubridate", "metacore", "metatools", "pharmaversesdtm", "pharmaverseadam", "stringr", "tern", "tidyr", "xportr"))
+```{r results = "asis", echo = FALSE}
+deps <- desc::desc(file = "DESCRIPTION")$get_deps()
+imported_deps <- deps[deps$type == "Imports" & deps$package != "desc", "package"]
+
+cat(
+  paste0(
+    "```r\n",
+    "install.packages(c(",
+    paste0("'", imported_deps, "'", collapse = ", "),
+    "))\n",
+    "```"
+  )
+)
+
 ```
 
 ## Contributing

--- a/index.qmd
+++ b/index.qmd
@@ -38,7 +38,7 @@ your own internal clinical reporting workflows!
 ### Locally
 To run examples locally, you can either:
 
-* Download the [repository](https://github.com/pharmaverse/examples) and run the following to install dependencies
+* Download the [repository](https://github.com/pharmaverse/examples) and run the following in the R console inside the project folder to install dependencies
 
 ```r
 if(!require(pak)) {
@@ -47,14 +47,6 @@ if(!require(pak)) {
 pak::pak()
 ```
 *Tip: If you prefer to run the examples as `.R` files instead of quarto documents, you can convert the `.qmd` files into Rscripts with [`knitr::purl`](https://bookdown.org/yihui/rmarkdown-cookbook/purl.html).*
-
-or,
-
-* Use the code provided below to install the necessary packages, then copy and paste the example code directly into your R console.
-
-```r
-install.packages(c("admiral", "dplyr", "lubridate", "metacore", "metatools", "pharmaversesdtm", "pharmaverseadam", "stringr", "tern", "tidyr", "xportr"))
-```
 
 ## Contributing
 If you are interesting in contributing an article to this book, then

--- a/index.qmd
+++ b/index.qmd
@@ -46,6 +46,7 @@ if(!require(pak)) {
 }
 pak::pak()
 ```
+*Tip: If you prefer to run the examples as `.R` files instead of quarto documents, you can convert the `.qmd` files into Rscripts with [`knitr::purl`](https://bookdown.org/yihui/rmarkdown-cookbook/purl.html).*
 
 or,
 

--- a/index.qmd
+++ b/index.qmd
@@ -41,10 +41,10 @@ To run examples locally, you can either:
 * Download the [repository](https://github.com/pharmaverse/examples) and run the following to install dependencies
 
 ```r
-if(!require(remotes)) {
-  install.packages("remotes")
+if(!require(pak)) {
+  install.packages("pak")
 }
-remotes::install_deps(dependencies = TRUE)
+pak::pak()
 ```
 
 or,

--- a/index.qmd
+++ b/index.qmd
@@ -22,7 +22,9 @@ packages can be used in conjunction - more thorough examples of individual
 package usages would always be covered in the package site vignettes and no
 need to repeat here.
 
-## Posit Cloud
+## Running the examples
+
+### Posit Cloud
 Each example can be explored via a live and interactive Posit Cloud environment
 (preconfigured with all required package installations).
 Click here: ["Launch Posit Cloud"](https://posit.cloud/content/7279124) to
@@ -32,6 +34,13 @@ e.g. `adam/adsl.qmd`. You could ignore the text sections and run the R code
 blocks.
 Feel free to try out customizing any of the examples to better fit any of
 your own internal clinical reporting workflows!
+
+### Locally
+To run all of the examples provided locally, first run the following line in your R console to install required packages.
+
+```r
+install.packages(c("admiral", "dplyr", "lubridate", "metacore", "metatools", "pharmaversesdtm", "pharmaverseadam", "stringr", "tern", "tidyr", "xportr"))
+```
 
 ## Contributing
 If you are interesting in contributing an article to this book, then

--- a/index.qmd
+++ b/index.qmd
@@ -36,7 +36,20 @@ Feel free to try out customizing any of the examples to better fit any of
 your own internal clinical reporting workflows!
 
 ### Locally
-To run all of the examples provided locally, first run the following line in your R console to install required packages.
+To run examples locally, you can either:
+
+* Download the [repository](https://github.com/pharmaverse/examples) and run the following to install dependencies
+
+```r
+if(!require(remotes)) {
+  install.packages("remotes")
+}
+remotes::install_deps(dependencies = TRUE)
+```
+
+or,
+
+* Use the code provided below to install the necessary packages, then copy and paste the example code directly into your R console.
 
 ```r
 install.packages(c("admiral", "dplyr", "lubridate", "metacore", "metatools", "pharmaversesdtm", "pharmaverseadam", "stringr", "tern", "tidyr", "xportr"))


### PR DESCRIPTION
Closes #28

## Changes

1. Created a h2 header `Running the examples` that contains Posit Cloud and Locally options
2. For running the examples locally, I've included 2 options. Former for cloning the repository and latter for copying and pasting the code from the examples book directly into the R console.