### PR TITLE
Fix code tag in the title

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,7 +8,7 @@ project:
     timeout: 300
 
 website:
-  title: "`pharmaverse` examples"
+  title: "pharmaverse examples"
   image: assets/img/pharmaverse.png
   open-graph: true
   favicon: assets/img/pharmaverse.png

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,3 @@
+code {
+  color: #7d12ba;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,3 +1,0 @@
-code {
-  color: #7d12ba;
-}


### PR DESCRIPTION
Closes #40

I saw that the `code` tag in the title is causing issues on the webpage. 

![image](https://github.com/pharmaverse/examples/assets/73589796/da4028a8-a507-4513-9368-f39b078ec568)


This is a [bug](https://github.com/quarto-dev/quarto-cli/discussions/8601) in quarto, the navbar always have `data-bs-theme="dark"` no matter if the dark mode is activated or not. I fixed it by ~making color styling constant for the code tag. This color is the default code color in bootstrap.~ Removing the code tag from the title for the word `pharmaverse`.

## Result
![image](https://github.com/pharmaverse/examples/assets/73589796/c9e90037-9e7e-44b0-a6d0-27e70850963a)
![image](https://github.com/pharmaverse/examples/assets/73589796/ed0613ab-79e3-4815-9c5c-84b662178117)

