### PR TITLE
hide hook_purl() outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
-editor: 
-  markdown: 
+editor:
+  markdown:
     wrap: 72
 ---
 
@@ -49,7 +49,8 @@ New Quarto pages should include the code snippet at the top for the
 scripts to be produced.
 
 ```{r setup script, include=FALSE, purl=FALSE}
-knitr::knit_hooks$set(purl = knitr::hook_purl)
+invisible_hook_purl <- function(before, options, ...) {knitr::hook_purl(before, options, ...); NULL}
+knitr::knit_hooks$set(purl = invisible_hook_purl)
 ```
 
 # Contributing

--- a/adam/adpc.qmd
+++ b/adam/adpc.qmd
@@ -4,7 +4,8 @@ order: 2
 ---
 
 ```{r setup script, include=FALSE, purl=FALSE}
-knitr::knit_hooks$set(purl = knitr::hook_purl)
+invisible_hook_purl <- function(before, options, ...) {knitr::hook_purl(before, options, ...); NULL}
+knitr::knit_hooks$set(purl = invisible_hook_purl)
 ```
 
 The Non-compartmental analysis (NCA) ADaM uses the CDISC Implementation Guide (<https://www.cdisc.org/standards/foundational/adam/adamig-non-compartmental-analysis-input-data-v1-0>). This example presented uses underlying `EX` and `PC` domains where the `EX` and `PC` domains represent data as collected and the `ADPC` ADaM is output. For more details see the `{admiral}` [vignette](https://pharmaverse.github.io/admiral/articles/pk_adnca.html){target="_blank"}.
@@ -31,7 +32,7 @@ library(pharmaverseadam)
 
 ## Next Load Specifications for Metacore
 
-We have saved our specifications in an Excel file and will load them into `{metacore}` with the `metacore::spec_to_metacore()` function. 
+We have saved our specifications in an Excel file and will load them into `{metacore}` with the `metacore::spec_to_metacore()` function.
 
 ```{r echo=TRUE}
 #| label: Load Specs
@@ -257,7 +258,7 @@ adpc_next <- adpc_prev %>%
 
 ### Find Previous and Next Nominal Dose
 
-Use the same method to find the previous and next nominal times. 
+Use the same method to find the previous and next nominal times.
 
 ```{r}
 #| label: Previous Nominal Dose
@@ -293,7 +294,7 @@ adpc_nom_next <- adpc_nom_prev %>%
 
 ### Combine PC and EX Data
 
-Combine `PC` and `EX` records and derive the additional relative time variables. 
+Combine `PC` and `EX` records and derive the additional relative time variables.
 
 ```{r}
 #| label: Combine
@@ -452,7 +453,7 @@ adpc_aval <- adpc_nrrlt %>%
 
 ### Derive DTYPE Copy Records
 
-The CDISC ADaM Implementation Guide for Non-compartmental Analysis uses duplicated records for analysis when a record needs to be used in more than one way. In this example the 24 hour post-dose record will also be used a the pre-dose record for the "Day 2" dose. 
+The CDISC ADaM Implementation Guide for Non-compartmental Analysis uses duplicated records for analysis when a record needs to be used in more than one way. In this example the 24 hour post-dose record will also be used a the pre-dose record for the "Day 2" dose.
 
 ```{r}
 #| label: DTYPE
@@ -537,7 +538,7 @@ adpc_aseq <- adpc_chg %>%
 
 ### Derive Additional Baselines
 
-Here we derive additional baseline values from `VS` for baseline height `HTBL` and weight `WTBL` and compute the body mass index (BMI) with `compute_bmi()`. 
+Here we derive additional baseline values from `VS` for baseline height `HTBL` and weight `WTBL` and compute the body mass index (BMI) with `compute_bmi()`.
 
 ```{r}
 #| label: Baselines

--- a/adam/adppk.qmd
+++ b/adam/adppk.qmd
@@ -4,7 +4,8 @@ order: 3
 ---
 
 ```{r setup script, include=FALSE, purl=FALSE}
-knitr::knit_hooks$set(purl = knitr::hook_purl)
+invisible_hook_purl <- function(before, options, ...) {knitr::hook_purl(before, options, ...); NULL}
+knitr::knit_hooks$set(purl = invisible_hook_purl)
 ```
 
 The Population PK Analysis Data (ADPPK) follows the CDISC Implementation Guide (<https://www.cdisc.org/standards/foundational/adam/basic-data-structure-adam-poppk-implementation-guide-v1-0>). Population PK models generally make use of nonlinear mixed effects models that require numeric variables. The data used in the models will include both dosing and concentration records, relative time variables, and numeric covariate variables. A `DV` or dependent variable is often expected. For more details see the `{admiral}` [vignette](https://pharmaverse.github.io/admiral/articles/pk_adnca.html){target="_blank"}.
@@ -32,7 +33,7 @@ library(pharmaverseadam)
 
 ## Next Load Specifications for Metacore
 
-We have saved our specifications in an Excel file and will load them into `{metacore}` with the `metacore::spec_to_metacore()` function. 
+We have saved our specifications in an Excel file and will load them into `{metacore}` with the `metacore::spec_to_metacore()` function.
 
 ```{r echo=TRUE, message=FALSE}
 #| label: Load Specs
@@ -265,7 +266,7 @@ adppk_nom_prev <- adppk_prev %>%
 
 ### Combine PC and EX Data
 
-Here we combine `PC` and `EX` records. We will derive the relative time variables `AFRLT` (Actual Relative Time from First Dose), `APRLT` (Actual Relative Time from Previous Dose), and `NPRLT` (Nominal Relative Time from Previous Dose). 
+Here we combine `PC` and `EX` records. We will derive the relative time variables `AFRLT` (Actual Relative Time from First Dose), `APRLT` (Actual Relative Time from Previous Dose), and `NPRLT` (Nominal Relative Time from Previous Dose).
 
 ```{r}
 #| label: Combine
@@ -448,7 +449,7 @@ covar <- adsl %>%
 
 ### Derive Additional Baselines
 
-Next we add additional baselines from vital signs and laboratory data. 
+Next we add additional baselines from vital signs and laboratory data.
 
 ```{r}
 #| label: Baselines
@@ -538,7 +539,7 @@ adppk <- adppk_prefinal %>%
 
 ## Apply Labels and Formats with xportr
 
-Using {xportr} we check variable type, assign variable lenght, add variable labels, add variable formats, and save a transport file with `xportr::xportr_write()`. 
+Using {xportr} we check variable type, assign variable lenght, add variable labels, add variable formats, and save a transport file with `xportr::xportr_write()`.
 
 ```{r}
 #| label: xportr

--- a/adam/adsl.qmd
+++ b/adam/adsl.qmd
@@ -4,7 +4,8 @@ order: 1
 ---
 
 ```{r setup script, include=FALSE, purl=FALSE}
-knitr::knit_hooks$set(purl = knitr::hook_purl)
+invisible_hook_purl <- function(before, options, ...) {knitr::hook_purl(before, options, ...); NULL}
+knitr::knit_hooks$set(purl = invisible_hook_purl)
 ```
 
 ## Introduction
@@ -35,7 +36,7 @@ library(tidyr)
 library(lubridate)
 library(stringr)
 
-# Read in input SDTM data 
+# Read in input SDTM data
 data("dm")
 data("ex")
 ```
@@ -43,9 +44,9 @@ data("ex")
 Next we need to load the specification file in the form of a `{metacore}` object.
 
 ```{r metacore, warning=FALSE, results='hold'}
-# Read in metacore object 
+# Read in metacore object
 load(metacore_example("pilot_ADaM.rda"))
-metacore <- metacore %>% 
+metacore <- metacore %>%
    select_dataset("ADSL")
 ```
 
@@ -66,8 +67,8 @@ build_from_derived(metacore, list(), predecessor_only = FALSE)
 In this case all the columns come from `DM` so that is the only dataset we will pass into `metatools::build_from_derived()`. The resulting dataset has all the columns combined and any columns that needed renaming between SDTM and ADaM are renamed.
 
 ```{r demographcis}
-adsl_preds <- build_from_derived(metacore, 
-                                 ds_list = list("dm" = dm), 
+adsl_preds <- build_from_derived(metacore,
+                                 ds_list = list("dm" = dm),
                                  predecessor_only = FALSE, keep = TRUE)
 head(adsl_preds, n=10)
 ```
@@ -83,12 +84,12 @@ Because this controlled terminology is written in a fairly standard format we ca
 Using a similar philosophy we can create the numeric version of `RACE` using the controlled terminology stored in the `{metacore}` object with the `metatools::create_var_from_codelist()` function.
 
 ```{r ct}
-adsl_ct <- adsl_preds %>% 
-   create_cat_var(metacore, ref_var = AGE, 
-                  grp_var = AGEGR1, num_grp_var = AGEGR1N) %>% 
-   create_var_from_codelist(metacore = metacore, 
-                            input_var = RACE, 
-                            out_var = RACEN) %>% 
+adsl_ct <- adsl_preds %>%
+   create_cat_var(metacore, ref_var = AGE,
+                  grp_var = AGEGR1, num_grp_var = AGEGR1N) %>%
+   create_var_from_codelist(metacore = metacore,
+                            input_var = RACE,
+                            out_var = RACEN) %>%
    #Removing screen failures from ARM and TRT01P to match the define and FDA guidence
    mutate(ARM = if_else(ARM == "Screen Failure", NA_character_, ARM),
           TRT01P = if_else(TRT01P == "Screen Failure", NA_character_, TRT01P)
@@ -132,14 +133,14 @@ adsl_raw <- adsl_ct %>%
     mode = "last",
     by_vars = exprs(STUDYID, USUBJID)
   ) %>%
-   derive_vars_dtm_to_dt(source_vars = exprs(TRTSDTM, TRTEDTM)) %>%  #Convert Datetime variables to date 
-   derive_var_trtdurd() %>% 
+   derive_vars_dtm_to_dt(source_vars = exprs(TRTSDTM, TRTEDTM)) %>%  #Convert Datetime variables to date
+   derive_var_trtdurd() %>%
    derive_var_merged_exist_flag(
      dataset_add = ex,
      by_vars = exprs(STUDYID, USUBJID),
      new_var = SAFFL,
      condition = (EXDOSE > 0 | (EXDOSE == 0 & str_detect(EXTRT, "PLACEBO")))
-   ) %>% 
+   ) %>%
    drop_unspec_vars(metacore) #This will drop any columns that aren't specified in the metacore object
 
 head(adsl_raw, n=10)
@@ -187,13 +188,13 @@ Now we have all the variables defined we can run some checks before applying the
 
 ```{r checks, warning=FALSE, message=FALSE}
 
-adsl_raw %>% 
+adsl_raw %>%
    check_variables(metacore) %>% # Check all variables specified are present and no more
    check_ct_data(metacore, na_acceptable = TRUE) %>% # Checks all variables with CT only contain values within the CT
    order_cols(metacore) %>% # Orders the columns according to the spec
-   sort_by_key(metacore) %>% # Sorts the rows by the sort keys 
+   sort_by_key(metacore) %>% # Sorts the rows by the sort keys
    xportr_type(metacore, domain = "ADSL") %>% # Coerce variable type to match spec
-   xportr_length(metacore) %>% # Assigns SAS length from a variable level metadata 
-   xportr_label(metacore) %>% # Assigns variable label from metacore specifications 
+   xportr_length(metacore) %>% # Assigns SAS length from a variable level metadata
+   xportr_label(metacore) %>% # Assigns variable label from metacore specifications
    xportr_df_label(metacore) # Assigns dataset label from metacore specifications
 ```

--- a/logging/logging.qmd
+++ b/logging/logging.qmd
@@ -1,6 +1,6 @@
 ---
 title: "The Difference Between `logr` And `logrx`"
-format: 
+format:
   html:
     code-overflow: wrap
 ---
@@ -53,22 +53,22 @@ log_close() # log file path: log/script.log
 
 ```{t}
 #| class: output-block
-========================================================================= 
-Log Path: ./log/script.log 
-Working Directory: /Users/davidblair/My Drive/Appsilon/Work Projects/examples 
-User Name: davidblair 
-R Version: 4.3.3 (2024-02-29) 
-Machine: Davids-Air.localdomain arm64 
-Operating System: Darwin 23.4.0 Darwin Kernel Version 23.4.0: Fri Mar 15 00:12:41 PDT 2024; root:xnu-10063.101.17~1/RELEASE_ARM64_T8103 
-Base Packages: stats graphics grDevices utils datasets methods base 
-Other Packages: dplyr_1.1.4 logr_1.3.6 
-Log Start Time: 2024-04-08 13:25:53.22436 
-========================================================================= 
+=========================================================================
+Log Path: ./log/script.log
+Working Directory: /Users/davidblair/My Drive/Appsilon/Work Projects/examples
+User Name: davidblair
+R Version: 4.3.3 (2024-02-29)
+Machine: Davids-Air.localdomain arm64
+Operating System: Darwin 23.4.0 Darwin Kernel Version 23.4.0: Fri Mar 15 00:12:41 PDT 2024; root:xnu-10063.101.17~1/RELEASE_ARM64_T8103
+Base Packages: stats graphics grDevices utils datasets methods base
+Other Packages: dplyr_1.1.4 logr_1.3.6
+Log Start Time: 2024-04-08 13:25:53.22436
+=========================================================================
 
-Analyzing Fuel Efficiency Trends in Cars 
+Analyzing Fuel Efficiency Trends in Cars
 
-NOTE: Log Print Time:  2024-04-08 13:25:53.226347 
-NOTE: Elapsed Time: 0.00139403343200684 secs 
+NOTE: Log Print Time:  2024-04-08 13:25:53.226347
+NOTE: Elapsed Time: 0.00139403343200684 secs
 
 # A tibble: 3 × 2
     cyl average_mpg
@@ -77,37 +77,37 @@ NOTE: Elapsed Time: 0.00139403343200684 secs
 2     6        19.7
 3     8        15.1
 
-NOTE: Data frame has 3 rows and 2 columns. 
+NOTE: Data frame has 3 rows and 2 columns.
 
-NOTE: Log Print Time:  2024-04-08 13:25:53.254377 
-NOTE: Elapsed Time: 0.0280299186706543 secs 
+NOTE: Log Print Time:  2024-04-08 13:25:53.254377
+NOTE: Elapsed Time: 0.0280299186706543 secs
 
 
 Call:
 lm(formula = mpg ~ wt, data = mtcars)
 
 Coefficients:
-(Intercept)           wt  
-     37.285       -5.344  
+(Intercept)           wt
+     37.285       -5.344
 
 
-NOTE: Log Print Time:  2024-04-08 13:25:53.267483 
-NOTE: Elapsed Time: 0.013106107711792 secs 
+NOTE: Log Print Time:  2024-04-08 13:25:53.267483
+NOTE: Elapsed Time: 0.013106107711792 secs
 
-========================================================================= 
-Log End Time: 2024-04-08 13:25:53.286294 
-Log Elapsed Time: 0 00:00:00 
-========================================================================= 
+=========================================================================
+Log End Time: 2024-04-08 13:25:53.286294
+Log Elapsed Time: 0 00:00:00
+=========================================================================
 ```
 
 ## `logrx`
 
-From the R terminal: 
+From the R terminal:
 ```{r, eval=FALSE}
 logrx::axecute("script.R")
 ```
 
-From the Command Line: 
+From the Command Line:
 ```{bash, eval=FALSE}
 Rscript -e "logrx::axecute('script.R')"
 ```
@@ -263,38 +263,38 @@ Run time: 0 seconds
 -                             Errors and Warnings                              -
 --------------------------------------------------------------------------------
 Errors:
-	
+
 
 Warnings:
-	
+
 --------------------------------------------------------------------------------
 -                         Messages, Output, and Result                         -
 --------------------------------------------------------------------------------
 Messages:
-	
+
 Output:
-	
+
 
 Result:
-	
+
 	Call:
 	lm(formula = mpg ~ wt, data = mtcars)
-	
+
 	Residuals:
-	    Min      1Q  Median      3Q     Max 
-	-4.5432 -2.3647 -0.1252  1.4096  6.8727 
-	
+	    Min      1Q  Median      3Q     Max
+	-4.5432 -2.3647 -0.1252  1.4096  6.8727
+
 	Coefficients:
-	            Estimate Std. Error t value Pr(>|t|)    
+	            Estimate Std. Error t value Pr(>|t|)
 	(Intercept)  37.2851     1.8776  19.858  < 2e-16 ***
 	wt           -5.3445     0.5591  -9.559 1.29e-10 ***
 	---
 	Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
-	
+
 	Residual standard error: 3.046 on 30 degrees of freedom
-	Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446 
+	Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446
 	F-statistic: 91.38 on 1 and 30 DF,  p-value: 1.294e-10
-	
+
 --------------------------------------------------------------------------------
 -                               Log Output File                                -
 --------------------------------------------------------------------------------
@@ -596,38 +596,38 @@ Run time: 0 seconds
 -                             Errors and Warnings                              -
 --------------------------------------------------------------------------------
 Errors:
-	
+
 
 Warnings:
-	
+
 --------------------------------------------------------------------------------
 -                         Messages, Output, and Result                         -
 --------------------------------------------------------------------------------
 Messages:
-	
+
 Output:
-	
+
 
 Result:
-	
+
 	Call:
 	lm(formula = mpg ~ wt, data = mtcars)
-	
+
 	Residuals:
-	    Min      1Q  Median      3Q     Max 
-	-4.5432 -2.3647 -0.1252  1.4096  6.8727 
-	
+	    Min      1Q  Median      3Q     Max
+	-4.5432 -2.3647 -0.1252  1.4096  6.8727
+
 	Coefficients:
-	            Estimate Std. Error t value Pr(>|t|)    
+	            Estimate Std. Error t value Pr(>|t|)
 	(Intercept)  37.2851     1.8776  19.858  < 2e-16 ***
 	wt           -5.3445     0.5591  -9.559 1.29e-10 ***
 	---
 	Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
-	
+
 	Residual standard error: 3.046 on 30 degrees of freedom
-	Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446 
+	Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446
 	F-statistic: 91.38 on 1 and 30 DF,  p-value: 1.294e-10
-	
+
 --------------------------------------------------------------------------------
 -                               Log Output File                                -
 --------------------------------------------------------------------------------
@@ -870,38 +870,38 @@ Run time: 0 seconds
 -                             Errors and Warnings                              -
 --------------------------------------------------------------------------------
 Errors:
-	
+
 
 Warnings:
-	
+
 --------------------------------------------------------------------------------
 -                         Messages, Output, and Result                         -
 --------------------------------------------------------------------------------
 Messages:
-	
+
 Output:
-	
+
 
 Result:
-	
+
 	Call:
 	lm(formula = mpg ~ wt, data = mtcars)
-	
+
 	Residuals:
-	    Min      1Q  Median      3Q     Max 
-	-4.5432 -2.3647 -0.1252  1.4096  6.8727 
-	
+	    Min      1Q  Median      3Q     Max
+	-4.5432 -2.3647 -0.1252  1.4096  6.8727
+
 	Coefficients:
-	            Estimate Std. Error t value Pr(>|t|)    
+	            Estimate Std. Error t value Pr(>|t|)
 	(Intercept)  37.2851     1.8776  19.858  < 2e-16 ***
 	wt           -5.3445     0.5591  -9.559 1.29e-10 ***
 	---
 	Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
-	
+
 	Residual standard error: 3.046 on 30 degrees of freedom
-	Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446 
+	Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446
 	F-statistic: 91.38 on 1 and 30 DF,  p-value: 1.294e-10
-	
+
 --------------------------------------------------------------------------------
 -                               Log Output File                                -
 --------------------------------------------------------------------------------

--- a/tlg/adverse_events.qmd
+++ b/tlg/adverse_events.qmd
@@ -5,7 +5,8 @@ order: 2
 
 
 ```{r setup script, include=FALSE, purl=FALSE}
-knitr::knit_hooks$set(purl = knitr::hook_purl)
+invisible_hook_purl <- function(before, options, ...) {knitr::hook_purl(before, options, ...); NULL}
+knitr::knit_hooks$set(purl = invisible_hook_purl)
 ```
 
 ## Introduction

--- a/tlg/demographic.qmd
+++ b/tlg/demographic.qmd
@@ -4,7 +4,8 @@ order: 1
 ---
 
 ```{r setup script, include=FALSE, purl=FALSE}
-knitr::knit_hooks$set(purl = knitr::hook_purl)
+invisible_hook_purl <- function(before, options, ...) {knitr::hook_purl(before, options, ...); NULL}
+knitr::knit_hooks$set(purl = invisible_hook_purl)
 knitr::opts_chunk$set(echo = TRUE)
 ```
 


### PR DESCRIPTION
follow-up on https://github.com/pharmaverse/examples/pull/51

I noticed that in the rendered webpage, below each code chunk we have displayed path to something.
![image](https://github.com/pharmaverse/examples/assets/12943682/b765c798-f000-46b7-8843-c60928653fbe)

It looks like it's due to `knitr::hook_purl()` implemented in the aforementioned PR. It returns a path and that returned value is included in the output HTML code. My idea is to wrap this up to a higher level function so that the script is still screated but that high-level function would return nothing.