### PR TITLE
Closes #159 preserve_pr_websites: keep files on gh-pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -58,10 +58,11 @@ jobs:
       - name: Publish docs
         # runs when main branch is updated, or when a PR is merged into main
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          keep_files: true
 
       - name: Publish PR docs in a subdirectory
         # runs when a PR is opened or updated, but not when merged into main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,8 +19,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "10 10 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Pull Request

Use `keep_files: true` to avoid that existing files on the `gh-pages` branch are removed when the website is build and deployed.

Before you submit your pull request, take a look at the following checklist. Many thanks for your contribution! 

- [x] **Title:** Place `Closes #<insert_issue_number>` at the beginning of your PR title. Use the Edit button in the top-right if you need to update.
- [x] **Linked Issue:** Ensure the related issue is linked in the "Development Section" on the right-hand side.
- [x] **First Contribution:** If this is your first contribution, add yourself to the `DESCRIPTION` file.
- [x] **Impact on Examples:** If your updates impact any examples, review locally for warnings or errors in the impacted example pages.
- [x] **Merge Conflicts:** Developers should address any merge conflicts and merge upon successful review.
- [x] **New Packages:** If new packages were used, ensure they are included in the `DESCRIPTION` file's `Imports` section.
- [x] **Landing Pages:** If new packages were added or removed, update the package tables in the [main landing page](../index.qmd) and the relevant section landing page(s) (`sdtm/index.qmd`, `adam/index.qmd`, `tlg/index.qmd`).
- [x] **Updated Examples:** If you added or updated an example, ensure it runs on the latest CRAN release versions of all packages used.
- [x] **Testing Instructions:** Provide instructions on how to test the code if necessary. 

By default, a temporary website with the content of the PR is created. To avoid this add `[skip website]` to the title of the PR.