### PR TITLE
fix: correct domain reference in ADAE example comments (#163)

### DIFF
--- a/adam/adae.R
+++ b/adam/adae.R
@@ -35,7 +35,7 @@ metacore <- spec_to_metacore(
 # Select required ADSL variables
 adsl_vars <- exprs(TRTSDT, TRTEDT, DTHDT)
 
-# Join ADSL variables with VS
+# Join ADSL variables with AE
 adae <- ae %>%
   derive_vars_merged(
     dataset_add = adsl,

--- a/adam/adae.qmd
+++ b/adam/adae.qmd
@@ -91,7 +91,7 @@ Some variables from the `ADSL` dataset required for the derivations are merged i
 # Select required ADSL variables
 adsl_vars <- exprs(TRTSDT, TRTEDT, DTHDT)
 
-# Join ADSL variables with VS
+# Join ADSL variables with AE
 adae <- ae %>%
   derive_vars_merged(
     dataset_add = adsl,


### PR DESCRIPTION
## What
Corrects a comment typo in the ADAE example files where the domain reference was incorrectly set to VS (Vital Signs) instead of AE (Adverse Events).

## Changes
- adam/adae.qmd: Changed '# Join ADSL variables with VS' to '# Join ADSL variables with AE'
- adam/adae.R: Changed '# Join ADSL variables with VS' to '# Join ADSL variables with AE'

## Context
The ADAE example joins ADSL variables with the AE domain (adverse events), not the VS domain (vital signs). The ADVS example files correctly reference VS. This is a comment-only fix with no functional impact.

Fixes #163